### PR TITLE
Show artist's release list with async cover arts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:backupAgent="org.metabrainz.mobile.backup.MusicBrainzBackupAgent"
         android:hardwareAccelerated="true"
         android:icon="@drawable/launcher"
+        android:usesCleartextTraffic="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/app/src/main/java/org/metabrainz/mobile/activity/ArtistActivity.java
+++ b/app/src/main/java/org/metabrainz/mobile/activity/ArtistActivity.java
@@ -51,7 +51,7 @@ public class ArtistActivity extends MusicBrainzActivity {
         findViews();
 
         releaseList = new ArrayList<>();
-        adapter = new ArtistReleaseAdapter(releaseList);
+        adapter = new ArtistReleaseAdapter(this, releaseList);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(adapter);
 
@@ -71,11 +71,38 @@ public class ArtistActivity extends MusicBrainzActivity {
         recyclerView = findViewById(R.id.recycler_view);
     }
 
-    private void setArtist(Artist data){
-        if(data != null){
-            artistViewModel.setArtist(data);
-            Log.d(LOG_TAG,data.getName());
-            setArtistInfo();
+    private void setArtist(Artist artist){
+        if (artist != null){
+            getSupportActionBar().setTitle(artist.getName());
+
+            String type = artist.getType();
+            if (type != null && !type.isEmpty()) {
+                artistType.setText(type);
+            }
+
+            String gender = artist.getGender();
+            if (gender != null && !gender.isEmpty()) {
+                artistGender.setText(gender);
+            }
+
+            if (artist.getArea() != null) {
+                artistArea.setText(artist.getArea().getName());
+            }
+
+            if (artist.getLifeSpan() != null) {
+                artistLifeSpan.setText(artist.getLifeSpan().getTimePeriod());
+            }
+
+            if (artist.getReleases() != null){
+                releaseList.clear();
+                releaseList.addAll(artist.getReleases());
+                adapter.notifyDataSetChanged();
+            }
+
+
+            //artistViewModel.setArtist(data);
+            //Log.d(LOG_TAG,data.getName());
+            //setArtistInfo();
         }
     }
 

--- a/app/src/main/java/org/metabrainz/mobile/activity/ArtistActivity.java
+++ b/app/src/main/java/org/metabrainz/mobile/activity/ArtistActivity.java
@@ -1,13 +1,8 @@
 package org.metabrainz.mobile.activity;
 
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
-
-import androidx.lifecycle.ViewModelProviders;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 
 import org.metabrainz.mobile.R;
 import org.metabrainz.mobile.adapter.list.ArtistReleaseAdapter;
@@ -22,6 +17,10 @@ import org.metabrainz.mobile.viewmodel.ArtistViewModel;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 /**
  * Activity that retrieves and displays information about an artist given an
  * artist MBID.
@@ -29,16 +28,15 @@ import java.util.List;
 public class ArtistActivity extends MusicBrainzActivity {
 
     public static final String LOG_TAG = "DebugArtistInfo";
+
     private ArtistViewModel artistViewModel;
-
-    private String mbid;
-
     private RecyclerView recyclerView;
     private ArtistReleaseAdapter adapter;
-    private List<Release> releaseList;
     private TextView wikiTextView, artistType, artistGender, artistArea, artistLifeSpan;
     private View wikiCard;
-    private Artist artist;
+
+    private String mbid;
+    private List<Release> releaseList;
 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -46,11 +44,11 @@ public class ArtistActivity extends MusicBrainzActivity {
         setSupportActionBar(findViewById(R.id.toolbar));
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        artistViewModel = ViewModelProviders.of(this).get(ArtistViewModel.class);
-
         findViews();
 
+        artistViewModel = ViewModelProviders.of(this).get(ArtistViewModel.class);
         releaseList = new ArrayList<>();
+
         adapter = new ArtistReleaseAdapter(this, releaseList);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(adapter);
@@ -58,6 +56,7 @@ public class ArtistActivity extends MusicBrainzActivity {
         mbid = getIntent().getStringExtra(IntentFactory.Extra.ARTIST_MBID);
         if(mbid != null && !mbid.isEmpty()) artistViewModel.setMBID(mbid);
 
+        // Whenever the artist changes, redraw the information
         artistViewModel.getArtistData().observe(this, this::setArtist);
     }
 
@@ -74,6 +73,8 @@ public class ArtistActivity extends MusicBrainzActivity {
     private void setArtist(Artist artist){
         if (artist != null){
             getSupportActionBar().setTitle(artist.getName());
+
+            getArtistWiki(artist);
 
             String type = artist.getType();
             if (type != null && !type.isEmpty()) {
@@ -94,19 +95,16 @@ public class ArtistActivity extends MusicBrainzActivity {
             }
 
             if (artist.getReleases() != null){
+                // Maybe releases get updated with cover art info
+                // Notify the adapter that the info is new
                 releaseList.clear();
                 releaseList.addAll(artist.getReleases());
                 adapter.notifyDataSetChanged();
             }
-
-
-            //artistViewModel.setArtist(data);
-            //Log.d(LOG_TAG,data.getName());
-            //setArtistInfo();
         }
     }
 
-    private void getArtistWiki(){
+    private void getArtistWiki(Artist artist){
         String title = "";
         int method = -1;
         if(artist != null)
@@ -143,38 +141,6 @@ public class ArtistActivity extends MusicBrainzActivity {
     }
     private void hideWikiCard(){
         wikiCard.setVisibility(View.GONE);
-    }
-
-    private void setArtistInfo(){
-        String type,gender,area,lifeSpan;
-        artist = artistViewModel.getArtist();
-
-        if(artist != null) {
-            getSupportActionBar().setTitle(artist.getName());
-
-            type = artist.getType();
-            gender = artist.getGender();
-            if(artist.getArea() != null) area = artist.getArea().getName(); else area = "";
-            if (artist.getLifeSpan() != null)
-                lifeSpan = artist.getLifeSpan().getTimePeriod();else lifeSpan = "";
-
-            if (type != null && !type.isEmpty())
-                artistType.setText(type);
-            if (gender != null && !gender.isEmpty())
-                artistGender.setText(gender);
-            if (area != null && !area.isEmpty())
-                artistArea.setText(area);
-            if (lifeSpan != null && !lifeSpan.isEmpty())
-                artistLifeSpan.setText(lifeSpan);
-
-            if(artist.getReleases() != null){
-                releaseList.clear();
-                releaseList.addAll(artist.getReleases());
-                adapter.notifyDataSetChanged();
-            }
-
-            getArtistWiki();
-        }
     }
 
     /*

--- a/app/src/main/java/org/metabrainz/mobile/adapter/list/ArtistReleaseAdapter.java
+++ b/app/src/main/java/org/metabrainz/mobile/adapter/list/ArtistReleaseAdapter.java
@@ -1,5 +1,6 @@
 package org.metabrainz.mobile.adapter.list;
 
+import android.content.Context;
 import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -8,14 +9,18 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.squareup.picasso.Picasso;
 
 import org.metabrainz.mobile.R;
+import org.metabrainz.mobile.activity.ArtistActivity;
 import org.metabrainz.mobile.api.data.search.entity.Release;
 import org.metabrainz.mobile.repository.LookupRepository;
+import org.metabrainz.mobile.viewmodel.ArtistViewModel;
 
 import java.util.List;
 
@@ -25,7 +30,14 @@ public class ArtistReleaseAdapter extends RecyclerView.Adapter {
 
     private List<Release> data;
     private LookupRepository repository = LookupRepository.getRepository();
-    public ArtistReleaseAdapter(List<Release> data){this.data = data;}
+    private Context context;
+    private ArtistViewModel artistViewModel;
+
+    public ArtistReleaseAdapter(Context context, List<Release> data){
+        this.context = context;
+        this.data = data;
+        artistViewModel = ViewModelProviders.of((FragmentActivity) context).get(ArtistViewModel.class);
+    }
 
     private class ReleaseItemViewHolder extends RecyclerView.ViewHolder{
         private MutableLiveData<List<Release>> coverArtMutableLiveData;
@@ -45,7 +57,8 @@ public class ArtistReleaseAdapter extends RecyclerView.Adapter {
             coverArtView.setVisibility(View.GONE);
 
             if(release.getCoverArt() != null) setCoverArtView(release);
-            else fetchSetCoverArtView(position);
+            else fetchCoverArtForRelease(release.getMbid(), position);
+            // else fetchSetCoverArtView(position);
         }
 
         private void setCoverArtView(Release release){
@@ -60,6 +73,12 @@ public class ArtistReleaseAdapter extends RecyclerView.Adapter {
             }
             if(!flag) coverArtView.setVisibility(View.GONE);
         }
+        private void fetchCoverArtForRelease(String releaseId, int position) {
+            // Ask the viewModel to retrieve the cover art
+            // and append it to this release
+            artistViewModel.fetchCoverArtForRelease(releaseId, position);
+        }
+
         private void fetchSetCoverArtView(int position){
             coverArtMutableLiveData = repository.fetchCoverArt(data,position);
             coverArtMutableLiveData.observeForever(releases -> {

--- a/app/src/main/java/org/metabrainz/mobile/adapter/list/ArtistReleaseAdapter.java
+++ b/app/src/main/java/org/metabrainz/mobile/adapter/list/ArtistReleaseAdapter.java
@@ -8,39 +8,34 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
-import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.ViewModelProviders;
-import androidx.recyclerview.widget.RecyclerView;
-
 import com.squareup.picasso.Picasso;
 
 import org.metabrainz.mobile.R;
-import org.metabrainz.mobile.activity.ArtistActivity;
 import org.metabrainz.mobile.api.data.search.entity.Release;
-import org.metabrainz.mobile.repository.LookupRepository;
 import org.metabrainz.mobile.viewmodel.ArtistViewModel;
 
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.RecyclerView;
 
 import static android.view.View.GONE;
 
 public class ArtistReleaseAdapter extends RecyclerView.Adapter {
 
-    private List<Release> data;
-    private LookupRepository repository = LookupRepository.getRepository();
-    private Context context;
+    private List<Release> releaseList;
     private ArtistViewModel artistViewModel;
 
-    public ArtistReleaseAdapter(Context context, List<Release> data){
-        this.context = context;
-        this.data = data;
+    public ArtistReleaseAdapter(Context context, List<Release> releaseList){
+        this.releaseList = releaseList;
+
+        // Load the ViewModel to fetch cover art for each release item
         artistViewModel = ViewModelProviders.of((FragmentActivity) context).get(ArtistViewModel.class);
     }
 
     private class ReleaseItemViewHolder extends RecyclerView.ViewHolder{
-        private MutableLiveData<List<Release>> coverArtMutableLiveData;
         TextView releaseName, releaseDisambiguation;
         ImageView coverArtView;
 
@@ -54,38 +49,24 @@ public class ArtistReleaseAdapter extends RecyclerView.Adapter {
         public void bind(Release release, int position){
             releaseName.setText(release.getTitle());
             setViewVisibility(release.getDisambiguation(), releaseDisambiguation);
-            coverArtView.setVisibility(View.GONE);
 
             if(release.getCoverArt() != null) setCoverArtView(release);
             else fetchCoverArtForRelease(release.getMbid(), position);
-            // else fetchSetCoverArtView(position);
         }
 
         private void setCoverArtView(Release release){
-            boolean flag = false;
-            if(release != null && release.getCoverArt() != null){
+            if (release != null && release.getCoverArt() != null){
+                // TODO: Search for the first “FRONT” image to use it as cover
                 String url = release.getCoverArt().getImages().get(0).getImage();
                 if (url != null && !url.isEmpty()) {
-                    coverArtView.setVisibility(View.VISIBLE);
                     Picasso.get().load(Uri.parse(url)).into(coverArtView);
-                    flag = true;
                 }
             }
-            if(!flag) coverArtView.setVisibility(View.GONE);
         }
         private void fetchCoverArtForRelease(String releaseId, int position) {
             // Ask the viewModel to retrieve the cover art
             // and append it to this release
             artistViewModel.fetchCoverArtForRelease(releaseId, position);
-        }
-
-        private void fetchSetCoverArtView(int position){
-            coverArtMutableLiveData = repository.fetchCoverArt(data,position);
-            coverArtMutableLiveData.observeForever(releases -> {
-                if (releases.get(position) != null)
-                    setCoverArtView(releases.get(position));
-                else coverArtView.setVisibility(View.GONE);
-            });
         }
     }
 
@@ -100,12 +81,12 @@ public class ArtistReleaseAdapter extends RecyclerView.Adapter {
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         ReleaseItemViewHolder viewHolder = (ReleaseItemViewHolder) holder;
-        viewHolder.bind(data.get(position) , position);
+        viewHolder.bind(releaseList.get(position) , position);
     }
 
     @Override
     public int getItemCount() {
-        return data.size();
+        return releaseList.size();
     }
 
     private void setViewVisibility(String text, TextView view) {

--- a/app/src/main/java/org/metabrainz/mobile/api/data/search/entity/Artist.java
+++ b/app/src/main/java/org/metabrainz/mobile/api/data/search/entity/Artist.java
@@ -42,6 +42,10 @@ public class Artist implements Serializable {
         this.releases = releases;
     }
 
+    public void setRelease(Release release, int position) {
+        this.releases.set(position, release);
+    }
+
     public ArrayList<Link> getRelations() {
         return relations;
     }

--- a/app/src/main/java/org/metabrainz/mobile/fragment/ArtistBioFragment.java
+++ b/app/src/main/java/org/metabrainz/mobile/fragment/ArtistBioFragment.java
@@ -6,16 +6,16 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProviders;
-
 import org.metabrainz.mobile.R;
 import org.metabrainz.mobile.api.data.ArtistWikiSummary;
 import org.metabrainz.mobile.api.data.search.entity.Artist;
 import org.metabrainz.mobile.api.data.search.entity.Link;
 import org.metabrainz.mobile.repository.LookupRepository;
 import org.metabrainz.mobile.viewmodel.ArtistViewModel;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProviders;
 
 public class ArtistBioFragment extends Fragment {
 
@@ -46,6 +46,7 @@ public class ArtistBioFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        // TODO: Observe artistData LiveData, instead of requesting the artist sync
         artist = artistViewModel.getArtist();
         setArtistInfo();
         getArtistWiki();

--- a/app/src/main/java/org/metabrainz/mobile/fragment/ArtistReleasesFragment.java
+++ b/app/src/main/java/org/metabrainz/mobile/fragment/ArtistReleasesFragment.java
@@ -34,7 +34,7 @@ public class ArtistReleasesFragment extends Fragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         releaseList = new ArrayList<>();
-        adapter = new ArtistReleaseAdapter(releaseList);
+        adapter = new ArtistReleaseAdapter(getActivity(), releaseList);
     }
 
     @Override

--- a/app/src/main/java/org/metabrainz/mobile/fragment/ArtistReleasesFragment.java
+++ b/app/src/main/java/org/metabrainz/mobile/fragment/ArtistReleasesFragment.java
@@ -5,12 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.lifecycle.ViewModelProviders;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-
 import org.metabrainz.mobile.R;
 import org.metabrainz.mobile.adapter.list.ArtistReleaseAdapter;
 import org.metabrainz.mobile.api.data.search.entity.Release;
@@ -18,6 +12,12 @@ import org.metabrainz.mobile.viewmodel.ArtistViewModel;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class ArtistReleasesFragment extends Fragment {
 
@@ -56,6 +56,7 @@ public class ArtistReleasesFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        // TODO: Observe artistData LiveData, instead of requesting the artist sync
         if(artistViewModel.getArtist() != null && artistViewModel.getArtist().getReleases() != null){
             releaseList.clear();
             releaseList.addAll(artistViewModel.getArtist().getReleases());

--- a/app/src/main/java/org/metabrainz/mobile/repository/LookupRepository.java
+++ b/app/src/main/java/org/metabrainz/mobile/repository/LookupRepository.java
@@ -1,5 +1,6 @@
 package org.metabrainz.mobile.repository;
 
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
 import com.google.gson.Gson;
@@ -16,10 +17,13 @@ import org.metabrainz.mobile.api.data.search.entity.Release;
 import org.metabrainz.mobile.api.webservice.Constants;
 import org.metabrainz.mobile.api.webservice.LookupService;
 import org.metabrainz.mobile.api.webservice.MusicBrainzServiceGenerator;
+import org.metabrainz.mobile.util.Log;
 import org.metabrainz.mobile.util.SingleLiveEvent;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import androidx.lifecycle.Transformations;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -32,6 +36,7 @@ public class LookupRepository {
     private final SingleLiveEvent<Artist> artistData;
     private final SingleLiveEvent<ArtistWikiSummary> artistWikiSummary;
     private final MutableLiveData<List<Release>> coverArtMutableLiveData;
+    private final MutableLiveData<CoverArt> coverArtData;
 
     public static final int METHOD_WIKIPEDIA_URL = 0;
     public static final int METHOD_WIKIDATA_ID = 1;
@@ -40,6 +45,27 @@ public class LookupRepository {
         artistData = new SingleLiveEvent<>();
         artistWikiSummary = new SingleLiveEvent<>();
         coverArtMutableLiveData  = new MutableLiveData<>();
+        coverArtData  = new MutableLiveData<>();
+
+        /*Transformations.switchMap(coverArtData, coverArt -> {
+            if (coverArt == null) {
+                return artistData;
+            }
+
+            Artist artist = artistData.getValue();
+            if (artist != null) {
+                ArrayList<Release> releases = artist.getReleases();
+
+                if (releases != null) {
+                    //Release release = releases.get(position);
+                    //release.setCoverArt(coverArt);
+                    //releases.set(position, release);
+                    //artist.setRelease(release, position);
+                    artistData.postValue(artist);
+                }
+            }
+            return artistData;
+        });*/
     }
 
     public static LookupRepository getRepository() {
@@ -53,6 +79,10 @@ public class LookupRepository {
         else
             fetchArtist(MBID);
         return artistData;
+    }
+
+    public LiveData<CoverArt> getCoverArtData() {
+        return coverArtData;
     }
 
     public SingleLiveEvent<ArtistWikiSummary> getArtistWikiSummary(String string, int method){
@@ -134,5 +164,46 @@ public class LookupRepository {
             }
         });
         return coverArtMutableLiveData;
+    }
+
+    public MutableLiveData<CoverArt> fetchCoverArtForRelease(String releaseId, int position){
+        if (artistData != null) {
+            Log.d("HAY DATOS");
+        }
+
+        service.getCoverArt(releaseId).enqueue(new Callback<CoverArt>() {
+            @Override
+            public void onResponse(Call<CoverArt> call, Response<CoverArt> response) {
+                CoverArt art = response.body();
+                if (response.code() == 200) {
+                    CoverArt coverArt = response.body();
+
+                    Artist artist = artistData.getValue();
+                    if (artist != null) {
+                        ArrayList<Release> releases = artist.getReleases();
+
+                        if (releases != null) {
+                            Release release = releases.get(position);
+                            release.setCoverArt(coverArt);
+                            //releases.set(position, release);
+                            artist.setRelease(release, position);
+                            artistData.postValue(artist);
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<CoverArt> call, Throwable t) {
+                Log.d(t.getLocalizedMessage());
+            }
+        });
+
+        return coverArtData;
+    }
+
+    public LiveData<Artist> updateArtistWithRelease() {
+        Log.d("ACTUALIZANDO");
+        return artistData;
     }
 }

--- a/app/src/main/java/org/metabrainz/mobile/viewmodel/ArtistViewModel.java
+++ b/app/src/main/java/org/metabrainz/mobile/viewmodel/ArtistViewModel.java
@@ -1,21 +1,29 @@
 package org.metabrainz.mobile.viewmodel;
 
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
 import androidx.lifecycle.ViewModel;
 
 import org.metabrainz.mobile.api.data.ArtistWikiSummary;
+import org.metabrainz.mobile.api.data.search.CoverArt;
+import org.metabrainz.mobile.api.data.search.Image;
 import org.metabrainz.mobile.api.data.search.entity.Artist;
 import org.metabrainz.mobile.api.data.search.entity.Release;
 import org.metabrainz.mobile.repository.LookupRepository;
+import org.metabrainz.mobile.util.Log;
 import org.metabrainz.mobile.util.SingleLiveEvent;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 public class ArtistViewModel extends ViewModel {
 
     private LookupRepository repository = LookupRepository.getRepository();
     private MutableLiveData<List<Release>> releasesLiveData;
-    private SingleLiveEvent<Artist> artistData;
+    private MutableLiveData<Artist> artistData;
+    private MutableLiveData<CoverArt> coverData;
     private Artist artist;
     private SingleLiveEvent<ArtistWikiSummary> artistWiki;
     private String MBID;
@@ -39,13 +47,13 @@ public class ArtistViewModel extends ViewModel {
         } else mbidHasChanged = false;
     }
 
-    public SingleLiveEvent<Artist> getArtistData(){
+    public MutableLiveData<Artist> getArtistData(){
         if (artistData == null || mbidHasChanged)
             artistData = loadArtistData();
         return artistData;
     }
 
-    private SingleLiveEvent<Artist> loadArtistData(){
+    private MutableLiveData<Artist> loadArtistData(){
         return repository.getArtist(MBID);
     }
 
@@ -53,6 +61,53 @@ public class ArtistViewModel extends ViewModel {
         if (artistWiki == null || mbidHasChanged)
             artistWiki = loadArtistWiki(title, method);
          return artistWiki;
+    }
+
+    public void fetchCoverArtForRelease(String releaseId, int position) {
+        // Ask the repository to fetch the cover art
+        //repository.fetchCoverArtForRelease(releaseId);
+        //final Image coverImage;
+
+        //LiveData<CoverArt> coverData = repository.fetchCoverArtForRelease(releaseId);
+
+//        Transformations.switchMap(coverData, (Function<CoverArt, LiveData<Artist>>) coverArt -> {
+//            Log.d("LLEGÓ");
+//            return repository.updateArtistWithRelease();
+//        });
+
+        repository.fetchCoverArtForRelease(releaseId, position);
+
+        /*Transformations.switchMap(repository.fetchCoverArtForRelease(releaseId), coverArt -> {
+            if (coverArt == null) {
+                return artistData;
+            }
+
+            Artist artist = artistData.getValue();
+            if (artist != null) {
+                ArrayList<Release> releases = artist.getReleases();
+
+                if (releases != null) {
+                    Release release = releases.get(position);
+                    release.setCoverArt(coverArt);
+                    releases.set(position, release);
+                    artist.setRelease(release, position);
+                    artistData.setValue(artist);
+                }
+            }
+            return artistData;
+        });*/
+
+//        artistData = Transformations.switchMap(
+//                coverData, (Function<CoverArt, LiveData<Artist>>) coverArt -> {
+//                    return repository.updateArtistWithRelease();
+//                });
+//
+//        Transformations.switchMap(fetchCoverArtForRelease(releaseId, position), repository::updateArtistWithRelease);
+
+
+
+
+        // Subscribe to its answer and map it to the release
     }
 
     private SingleLiveEvent<ArtistWikiSummary> loadArtistWiki(String title, int method){

--- a/app/src/main/java/org/metabrainz/mobile/viewmodel/ArtistViewModel.java
+++ b/app/src/main/java/org/metabrainz/mobile/viewmodel/ArtistViewModel.java
@@ -1,47 +1,37 @@
 package org.metabrainz.mobile.viewmodel;
 
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MutableLiveData;
-import androidx.lifecycle.Transformations;
-import androidx.lifecycle.ViewModel;
-
 import org.metabrainz.mobile.api.data.ArtistWikiSummary;
-import org.metabrainz.mobile.api.data.search.CoverArt;
-import org.metabrainz.mobile.api.data.search.Image;
 import org.metabrainz.mobile.api.data.search.entity.Artist;
-import org.metabrainz.mobile.api.data.search.entity.Release;
 import org.metabrainz.mobile.repository.LookupRepository;
-import org.metabrainz.mobile.util.Log;
 import org.metabrainz.mobile.util.SingleLiveEvent;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
 
 public class ArtistViewModel extends ViewModel {
 
     private LookupRepository repository = LookupRepository.getRepository();
-    private MutableLiveData<List<Release>> releasesLiveData;
     private MutableLiveData<Artist> artistData;
-    private MutableLiveData<CoverArt> coverData;
     private Artist artist;
     private SingleLiveEvent<ArtistWikiSummary> artistWiki;
     private String MBID;
-    public boolean mbidHasChanged = true;
+    private boolean mbidHasChanged = true;
 
     public ArtistViewModel() {
     }
 
+    // TODO: Remove to use only LiveData getter
     public Artist getArtist() {
         return artist;
     }
 
+    // TODO: Remove to use only LiveData getter
     public void setArtist(Artist artist) {
         this.artist = artist;
     }
 
     public void setMBID(String MBID) {
-        if(MBID != null && !MBID.isEmpty()) {
+        if (MBID != null && !MBID.isEmpty()) {
             this.MBID = MBID;
             mbidHasChanged = true;
         } else mbidHasChanged = false;
@@ -49,12 +39,8 @@ public class ArtistViewModel extends ViewModel {
 
     public MutableLiveData<Artist> getArtistData(){
         if (artistData == null || mbidHasChanged)
-            artistData = loadArtistData();
+            artistData = repository.getArtist(MBID);
         return artistData;
-    }
-
-    private MutableLiveData<Artist> loadArtistData(){
-        return repository.getArtist(MBID);
     }
 
     public SingleLiveEvent<ArtistWikiSummary> getArtistWiki(String title, int method){
@@ -64,58 +50,12 @@ public class ArtistViewModel extends ViewModel {
     }
 
     public void fetchCoverArtForRelease(String releaseId, int position) {
-        // Ask the repository to fetch the cover art
-        //repository.fetchCoverArtForRelease(releaseId);
-        //final Image coverImage;
-
-        //LiveData<CoverArt> coverData = repository.fetchCoverArtForRelease(releaseId);
-
-//        Transformations.switchMap(coverData, (Function<CoverArt, LiveData<Artist>>) coverArt -> {
-//            Log.d("LLEGÓ");
-//            return repository.updateArtistWithRelease();
-//        });
-
+        // Ask the repository to fetch the cover art and update ArtistData LiveData
+        // Whoever is observing that LiveData, will receive the release with the cover art
         repository.fetchCoverArtForRelease(releaseId, position);
-
-        /*Transformations.switchMap(repository.fetchCoverArtForRelease(releaseId), coverArt -> {
-            if (coverArt == null) {
-                return artistData;
-            }
-
-            Artist artist = artistData.getValue();
-            if (artist != null) {
-                ArrayList<Release> releases = artist.getReleases();
-
-                if (releases != null) {
-                    Release release = releases.get(position);
-                    release.setCoverArt(coverArt);
-                    releases.set(position, release);
-                    artist.setRelease(release, position);
-                    artistData.setValue(artist);
-                }
-            }
-            return artistData;
-        });*/
-
-//        artistData = Transformations.switchMap(
-//                coverData, (Function<CoverArt, LiveData<Artist>>) coverArt -> {
-//                    return repository.updateArtistWithRelease();
-//                });
-//
-//        Transformations.switchMap(fetchCoverArtForRelease(releaseId, position), repository::updateArtistWithRelease);
-
-
-
-
-        // Subscribe to its answer and map it to the release
     }
 
     private SingleLiveEvent<ArtistWikiSummary> loadArtistWiki(String title, int method){
         return repository.getArtistWikiSummary(title ,method);
     }
-
-    private MutableLiveData<List<Release>> initializeListData(List<Release> releases, int position){
-        return repository.fetchCoverArt(releases,position);
-    }
-
 }

--- a/app/src/main/res/layout/card_release.xml
+++ b/app/src/main/res/layout/card_release.xml
@@ -13,40 +13,54 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/release_name"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:textAppearance="?android:attr/textAppearanceListItem"
-            android:textColor="@color/black"
-            android:gravity="center"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/cover_art"
-            tools:text="Release Name" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
+            <ImageView
+                android:id="@+id/cover_art"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_margin="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/link_discog"
+                tools:srcCompat="@tools:sample/avatars" />
 
-        <TextView
-            android:id="@+id/release_disambiguation"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:gravity="center"
-            app:layout_constraintTop_toBottomOf="@+id/release_name"
-            tools:text="Disambiguation" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/cover_art"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:srcCompat="@tools:sample/avatars" />
+                <TextView
+                    android:id="@+id/release_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:gravity="center"
+                    android:textAppearance="?android:attr/textAppearanceListItem"
+                    android:textColor="@color/black"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/cover_art"
+                    tools:text="Release Name" />
+
+                <TextView
+                    android:id="@+id/release_disambiguation"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="8dp"
+                    android:gravity="center"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/release_name"
+                    tools:text="Disambiguation" />
+            </LinearLayout>
+        </LinearLayout>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
(PR's base is `test-rx` to see only my changes. Once reviewed it can be changed to `master`, to include all changes)

# Changes
I've stablished a workflow to use LiveData to fetch cover arts for each release async. This updates the artist LiveData that is observed by the Activity.

## Workflow
1. `ReleaseItemViewHolder` asks the repo to fetch the cover art for this release
2. Repo fetches it and updates the artist LiveData by searching the given release and updating it's cover art.
3. As Activity is observing the artist LiveData, when the repo posts a new value, Activity observes it and notifies the adapter that there's new data (release with cover art)

## TO DO

- ℹ️ I've set a place holder for the covers, to prevent the row to have different heights.
- 🚨 I've included `android:usesCleartextTraffic="true"` because the Cover Art API's HTTPS certificate is not properly configured. We have to check on this to use only HTTPS in the app.

# Preview

![artist-releases](https://user-images.githubusercontent.com/465723/54429164-0d596a00-4720-11e9-8bde-2de8323046a5.gif)